### PR TITLE
Check for proxy SSL headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ func main() {
 		ContentTypeNosniff:    true,
 		BrowserXssFilter:      true,
 		ContentSecurityPolicy: "default-src 'self'",
-		ReferrerPolicy:        "strict-origin-when-cross-origin",
 		IENoOpen:              true,
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
 		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ func DefaultConfig() Config {
 		BrowserXssFilter:      true,
 		ContentSecurityPolicy: "default-src 'self'",
 		IENoOpen:              true,
-		//SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
+		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	}
 }
 ```
@@ -56,6 +56,7 @@ func main() {
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
 		IENoOpen:              true,
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
+		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	}))
 
 	router.GET("/ping", func(c *gin.Context) {

--- a/example/code1/example.go
+++ b/example/code1/example.go
@@ -18,9 +18,9 @@ func main() {
 		ContentTypeNosniff:    true,
 		BrowserXssFilter:      true,
 		ContentSecurityPolicy: "default-src 'self'",
-		ReferrerPolicy:        "strict-origin-when-cross-origin",
 		IENoOpen:              true,
 		ReferrerPolicy:        "strict-origin-when-cross-origin",
+		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	}))
 
 	router.GET("/ping", func(c *gin.Context) {

--- a/policy.go
+++ b/policy.go
@@ -133,13 +133,33 @@ func (p *policy) checkAllowHosts(c *gin.Context) bool {
 	return false
 }
 
+func (p *policy) isSSLRequest(req *http.Request) bool {
+	if strings.EqualFold(req.URL.Scheme, "https") || req.TLS != nil {
+		return true
+	}
+
+	for h, v := range p.config.SSLProxyHeaders {
+		hv, ok := req.Header[h]
+
+		if !ok {
+			continue
+		}
+		
+		if strings.EqualFold(hv[0], v) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (p *policy) checkSSL(c *gin.Context) bool {
 	if !p.config.SSLRedirect {
 		return true
 	}
 
 	req := c.Request
-	isSSLRequest := strings.EqualFold(req.URL.Scheme, "https") || req.TLS != nil
+	isSSLRequest := p.isSSLRequest(req)
 	if isSSLRequest {
 		return true
 	}

--- a/secure.go
+++ b/secure.go
@@ -62,6 +62,7 @@ type Config struct {
 //		ContentTypeNosniff:    true
 //		BrowserXssFilter:      true
 //		ContentSecurityPolicy: "default-src 'self'"
+//      SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 // ```
 func DefaultConfig() Config {
 	return Config{

--- a/secure.go
+++ b/secure.go
@@ -47,8 +47,9 @@ type Config struct {
 	// Prevent Internet Explorer from executing downloads in your site’s context
 	IENoOpen bool
 
-	// TODO
-	// SSLProxyHeaders map[string]string
+	// If the request is insecure, treat it as secure if any of the headers in this dict are set to their corresponding value
+	// This is useful when your app is running behind a secure proxy that forwards requests to your app over http (such as on Heroku).
+	SSLProxyHeaders map[string]string
 }
 
 // DefaultConfig returns a Configuration with strict security settings.
@@ -73,7 +74,7 @@ func DefaultConfig() Config {
 		BrowserXssFilter:      true,
 		ContentSecurityPolicy: "default-src 'self'",
 		IENoOpen:              true,
-		//SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
+		SSLProxyHeaders:       map[string]string{"X-Forwarded-Proto": "https"},
 	}
 }
 


### PR DESCRIPTION
This was left as a todo in the codebase, and this feature is extremely useful to me at the moment, so I made a quick implementation.

One question, though, is how to treat multiple values for `SSLProxyHeaders`. The current code considers the request secure if any of the headers in the map match. Is this what we want, or should it only be secure if **all** of the headers in the map match?