### PR TITLE
DontRedirectIPV4Hostnames flag for load balancer health-checks

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -141,8 +141,7 @@ func (p *policy) checkAllowHosts(c *gin.Context) bool {
 
 // checks if a host (possibly with trailing port) is an IPV4 address
 func isIPV4(host string) bool {
-	index := strings.IndexByte(host, ':')
-		if index != -1 {
+	if index := strings.IndexByte(host, ':'); index != -1 {
 		host = host[:index]
 	}
 	return net.ParseIP(host) != nil

--- a/policy.go
+++ b/policy.go
@@ -2,6 +2,7 @@ package secure
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -136,6 +137,15 @@ func (p *policy) checkAllowHosts(c *gin.Context) bool {
 	}
 
 	return false
+}
+
+// checks if a host (possibly with trailing port) is an IPV4 address
+func isIPV4(host string) bool {
+	index := strings.IndexByte(host, ':')
+		if index != -1 {
+		host = host[:index]
+	}
+	return net.ParseIP(host) != nil
 }
 
 func (p *policy) isSSLRequest(req *http.Request) bool {

--- a/policy.go
+++ b/policy.go
@@ -165,6 +165,10 @@ func (p *policy) isSSLRequest(req *http.Request) bool {
 		}
 	}
 
+	if p.config.DontRedirectIPV4Hostnames && isIPV4(req.Host) {
+		return true
+	}
+
 	return false
 }
 

--- a/secure.go
+++ b/secure.go
@@ -48,6 +48,10 @@ type Config struct {
 	IENoOpen bool
 	// Feature Policy is a new header that allows a site to control which features and APIs can be used in the browser.
 	FeaturePolicy string
+	// If DontRedirectIPV4Hostnames is true, requests to hostnames that are IPV4
+	// addresses aren't redirected. This is to allow load balancer health checks
+	// to succeed.
+	DontRedirectIPV4Hostnames bool
 
 	// If the request is insecure, treat it as secure if any of the headers in this dict are set to their corresponding value
 	// This is useful when your app is running behind a secure proxy that forwards requests to your app over http (such as on Heroku).

--- a/secure_test.go
+++ b/secure_test.go
@@ -173,6 +173,19 @@ func TestBasicSSL(t *testing.T) {
 	assert.Equal(t, "https://www.example.com/foo", w.Header().Get("Location"))
 }
 
+func TestDontRedirectIPV4Hostnames(t *testing.T) {
+	router := newServer(Config{
+		SSLRedirect: true,
+		DontRedirectIPV4Hostnames: true,
+	})
+
+	w1 := performRequest(router, "http://www.example.com/foo")
+	assert.Equal(t, http.StatusMovedPermanently, w1.Code)
+
+	w2 := performRequest(router, "http://127.0.0.1/foo")
+	assert.Equal(t, http.StatusOK, w2.Code)
+}
+
 func TestBasicSSLWithHost(t *testing.T) {
 	router := newServer(Config{
 		SSLRedirect: true,

--- a/secure_test.go
+++ b/secure_test.go
@@ -371,3 +371,12 @@ func TestInlineSecure(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
 }
+
+func TestIsIpv4Host(t *testing.T) {
+	assert.Equal(t, isIPV4("127.0.0.1"), true)
+	assert.Equal(t, isIPV4("127.0.0.1:8080"), true)
+	assert.Equal(t, isIPV4("localhost"), false)
+	assert.Equal(t, isIPV4("localhost:8080"), false)
+	assert.Equal(t, isIPV4("example.com"), false)
+	assert.Equal(t, isIPV4("example.com:8080"), false)
+}


### PR DESCRIPTION
## Why
* health check requests from proxies & load balancers will usually be insecure, but still need to 200
* if a backend server responds with a 3xx, it will never become 'ready' and the LB won't send it traffic
## What
* add a DontRedirectIPV4Hostnames flag
* when the hostname of a request is an IPV4 address (or an address with a port, like `10.0.0.1:8080`), and this flag is true, the middleware treats the request as secure
