### PR TITLE
fix: keep includeSubdomains when STSPreload is enabled

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -68,7 +68,7 @@ func (p *policy) loadConfig(config Config) {
 			stsSub = "; includeSubdomains"
 		}
 		if config.STSPreload {
-			stsSub = "; preload"
+			stsSub += "; preload"
 		}
 		// TODO
 		// "max-age=%d%s" refactor

--- a/secure_test.go
+++ b/secure_test.go
@@ -285,6 +285,19 @@ func TestStsHeaderWithSubdomain(t *testing.T) {
 	assert.Equal(t, "max-age=315360000; includeSubdomains", w.Header().Get("Strict-Transport-Security"))
 }
 
+func TestStsHeaderWithSubdomainAndPreload(t *testing.T) {
+	router := newServer(Config{
+		STSSeconds:           315360000,
+		STSIncludeSubdomains: true,
+		STSPreload:           true,
+	})
+
+	w := performRequest(router, "/foo")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "max-age=315360000; includeSubdomains; preload", w.Header().Get("Strict-Transport-Security"))
+}
+
 func TestFrameDeny(t *testing.T) {
 	router := newServer(Config{
 		FrameDeny: true,


### PR DESCRIPTION
When both `STSIncludeSubdomains` and `STSPreload` are set, the
`Strict-Transport-Security` header drops `includeSubdomains` and only sends:

    max-age=315360000; preload

The preload branch in `policy.go` was overwriting `stsSub` instead of
appending to it:

```go
if config.STSPreload {
    stsSub = "; preload"
}
```

Changed it to `+=` so both directives are kept:

    max-age=315360000; includeSubdomains; preload

Added a test for the both-enabled case.

Note: #52 also asks whether `STSPreload` should be enabled by default in
`DefaultConfig()`. I left that out here since it changes default behaviour —
happy to do a follow-up if you'd like.

Refs #52
